### PR TITLE
Run linters on whole codebase

### DIFF
--- a/tensorpipe/.clang-tidy
+++ b/tensorpipe/.clang-tidy
@@ -1,0 +1,8 @@
+---
+InheritParentConfig: true
+Checks: '
+readability-inconsistent-declaration-parameter-name,
+readability-named-parameter,
+'
+FormatStyle: file
+...

--- a/tensorpipe/CMakeLists.txt
+++ b/tensorpipe/CMakeLists.txt
@@ -71,6 +71,13 @@ if(TP_USE_CUDA)
     channel/cuda_xth/channel.cc
     channel/cuda_xth/context.cc)
 
+  ### cuda_basic
+
+  target_sources(tensorpipe PRIVATE
+    channel/cuda_basic/channel.cc
+    channel/cuda_basic/context.cc
+    common/cuda_loop.cc)
+
   ### cuda_ipc
 
   if(TP_ENABLE_CUDA_IPC)

--- a/tensorpipe/channel/basic/channel.cc
+++ b/tensorpipe/channel/basic/channel.cc
@@ -27,9 +27,9 @@ namespace basic {
 class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
  public:
   Impl(
-      std::shared_ptr<Context::PrivateIface>,
-      std::shared_ptr<transport::Connection>,
-      std::string);
+      std::shared_ptr<Context::PrivateIface> context,
+      std::shared_ptr<transport::Connection> connection,
+      std::string id);
 
   // Called by the channel's constructor.
   void init();

--- a/tensorpipe/channel/basic/channel.h
+++ b/tensorpipe/channel/basic/channel.h
@@ -26,7 +26,7 @@ class Channel : public channel::CpuChannel {
 
  public:
   Channel(
-      ConstructorToken,
+      ConstructorToken token,
       std::shared_ptr<Context::PrivateIface> context,
       std::shared_ptr<transport::Connection> connection,
       std::string id);

--- a/tensorpipe/channel/basic/context.cc
+++ b/tensorpipe/channel/basic/context.cc
@@ -32,8 +32,8 @@ class Context::Impl : public Context::PrivateIface,
   const std::string& domainDescriptor() const;
 
   std::shared_ptr<channel::CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection>,
-      Endpoint);
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint);
 
   void setId(std::string id);
 

--- a/tensorpipe/channel/basic/context.h
+++ b/tensorpipe/channel/basic/context.h
@@ -24,8 +24,8 @@ class Context : public channel::CpuContext {
   const std::string& domainDescriptor() const override;
 
   std::shared_ptr<CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection>,
-      Endpoint) override;
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint) override;
 
   void setId(std::string id) override;
 

--- a/tensorpipe/channel/cma/channel.cc
+++ b/tensorpipe/channel/cma/channel.cc
@@ -49,9 +49,9 @@ struct Descriptor {
 class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
  public:
   Impl(
-      std::shared_ptr<Context::PrivateIface>,
-      std::shared_ptr<transport::Connection>,
-      std::string);
+      std::shared_ptr<Context::PrivateIface> context,
+      std::shared_ptr<transport::Connection> connection,
+      std::string id);
 
   // Called by the channel's constructor.
   void init();

--- a/tensorpipe/channel/cma/channel.h
+++ b/tensorpipe/channel/cma/channel.h
@@ -26,8 +26,8 @@ class Channel : public channel::CpuChannel {
 
  public:
   Channel(
-      ConstructorToken,
-      std::shared_ptr<Context::PrivateIface>,
+      ConstructorToken token,
+      std::shared_ptr<Context::PrivateIface> context,
       std::shared_ptr<transport::Connection> connection,
       std::string id);
 

--- a/tensorpipe/channel/cma/context.cc
+++ b/tensorpipe/channel/cma/context.cc
@@ -68,8 +68,8 @@ class Context::Impl : public Context::PrivateIface,
   const std::string& domainDescriptor() const;
 
   std::shared_ptr<channel::CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection>,
-      Endpoint);
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint);
 
   void setId(std::string id);
 

--- a/tensorpipe/channel/cma/context.h
+++ b/tensorpipe/channel/cma/context.h
@@ -24,8 +24,8 @@ class Context : public channel::CpuContext {
   const std::string& domainDescriptor() const override;
 
   std::shared_ptr<CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection>,
-      Endpoint) override;
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint) override;
 
   void setId(std::string id) override;
 

--- a/tensorpipe/channel/cuda_basic/channel.cc
+++ b/tensorpipe/channel/cuda_basic/channel.cc
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/cuda_basic/channel.h>
+
+#include <algorithm>
+#include <condition_variable>
+#include <list>
+#include <mutex>
+
+#include <tensorpipe/channel/cuda_basic/context_impl.h>
+#include <tensorpipe/channel/error.h>
+#include <tensorpipe/channel/helpers.h>
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/cuda.h>
+#include <tensorpipe/common/cuda_loop.h>
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/error.h>
+#include <tensorpipe/common/error_macros.h>
+#include <tensorpipe/transport/connection.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_basic {
+
+class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
+ public:
+  Impl(
+      std::shared_ptr<Context::PrivateIface> context,
+      std::shared_ptr<CpuChannel> cpuChannel,
+      CudaLoop& cudaLoop,
+      std::string id);
+
+  // Called by the channel's constructor.
+  void init();
+
+  void send(
+      CudaBuffer buffer,
+      TDescriptorCallback descriptorCallback,
+      TSendCallback callback);
+
+  void recv(TDescriptor descriptor, CudaBuffer buffer, TRecvCallback callback);
+
+  // Tell the channel what its identifier is.
+  void setId(std::string id);
+
+  void close();
+
+ private:
+  OnDemandDeferredExecutor loop_;
+
+  void initFromLoop();
+
+  // Send memory region to peer.
+  void sendFromLoop(
+      CudaBuffer buffer,
+      TDescriptorCallback descriptorCallback,
+      TSendCallback callback);
+
+  void onTempBufferReadyForSend(
+      CudaBuffer buffer,
+      CudaPinnedBuffer tmpBuffer,
+      TDescriptorCallback descriptorCallback);
+
+  // Receive memory region from peer.
+  void recvFromLoop(
+      TDescriptor descriptor,
+      CudaBuffer buffer,
+      TRecvCallback callback);
+
+  void onCpuChannelRecv(
+      CudaBuffer buffer,
+      CudaPinnedBuffer tmpBuffer,
+      TRecvCallback callback);
+
+  void closeFromLoop();
+
+  void setError(Error error);
+
+  void setIdFromLoop(std::string id);
+
+  // Helper function to process transport error.
+  // Shared between read and write callback entry points.
+  void handleError();
+
+  std::shared_ptr<Context::PrivateIface> context_;
+  std::shared_ptr<CpuChannel> cpuChannel_;
+  CudaLoop& cudaLoop_;
+  Error error_{Error::kSuccess};
+
+  ClosingReceiver closingReceiver_;
+
+  // Increasing identifier for send operations.
+  uint64_t nextTensorBeingSent_{0};
+
+  // Increasing identifier for recv operations.
+  uint64_t nextTensorBeingReceived_{0};
+
+  // An identifier for the channel, composed of the identifier for the context,
+  // combined with an increasing sequence number. It will only be used for
+  // logging and debugging purposes.
+  std::string id_;
+
+  EagerCallbackWrapper<Impl> eagerCallbackWrapper_{*this, this->loop_};
+
+  // For some odd reason it seems we need to use a qualified name here...
+  template <typename T>
+  friend class tensorpipe::EagerCallbackWrapper;
+};
+
+Channel::Channel(
+    ConstructorToken /* unused */,
+    std::shared_ptr<Context::PrivateIface> context,
+    std::shared_ptr<CpuChannel> cpuChannel,
+    CudaLoop& cudaLoop,
+    std::string id)
+    : impl_(std::make_shared<Impl>(
+          std::move(context),
+          std::move(cpuChannel),
+          cudaLoop,
+          std::move(id))) {
+  impl_->init();
+}
+
+Channel::Impl::Impl(
+    std::shared_ptr<Context::PrivateIface> context,
+    std::shared_ptr<CpuChannel> cpuChannel,
+    CudaLoop& cudaLoop,
+    std::string id)
+    : context_(std::move(context)),
+      cpuChannel_(std::move(cpuChannel)),
+      cudaLoop_(cudaLoop),
+      closingReceiver_(context_, context_->getClosingEmitter()),
+      id_(std::move(id)) {}
+
+void Channel::Impl::init() {
+  loop_.deferToLoop([this]() { initFromLoop(); });
+}
+
+void Channel::Impl::initFromLoop() {
+  TP_DCHECK(loop_.inLoop());
+  closingReceiver_.activate(*this);
+}
+
+void Channel::send(
+    CudaBuffer buffer,
+    TDescriptorCallback descriptorCallback,
+    TSendCallback callback) {
+  impl_->send(buffer, std::move(descriptorCallback), std::move(callback));
+}
+
+void Channel::Impl::send(
+    CudaBuffer buffer,
+    TDescriptorCallback descriptorCallback,
+    TSendCallback callback) {
+  loop_.deferToLoop([this,
+                     buffer,
+                     descriptorCallback{std::move(descriptorCallback)},
+                     callback{std::move(callback)}]() mutable {
+    sendFromLoop(buffer, std::move(descriptorCallback), std::move(callback));
+  });
+}
+
+// Send memory region to peer.
+void Channel::Impl::sendFromLoop(
+    CudaBuffer buffer,
+    TDescriptorCallback descriptorCallback,
+    TSendCallback callback) {
+  TP_DCHECK(loop_.inLoop());
+
+  const uint64_t sequenceNumber = nextTensorBeingSent_++;
+  TP_VLOG(4) << "Channel " << id_ << " received a send request (#"
+             << sequenceNumber << ")";
+
+  descriptorCallback = [this,
+                        sequenceNumber,
+                        descriptorCallback{std::move(descriptorCallback)}](
+                           const Error& error, TDescriptor descriptor) {
+    // There is no requirement for the channel to invoke callbacks in order.
+    TP_VLOG(4) << "Channel " << id_ << " is calling a descriptor callback (#"
+               << sequenceNumber << ")";
+    descriptorCallback(error, std::move(descriptor));
+    TP_VLOG(4) << "Channel " << id_ << " done calling a descriptor callback (#"
+               << sequenceNumber << ")";
+  };
+
+  callback = [this, sequenceNumber, callback{std::move(callback)}](
+                 const Error& error) {
+    TP_VLOG(4) << "Channel " << id_ << " is calling a send callback (#"
+               << sequenceNumber << ")";
+    callback(error);
+    TP_VLOG(4) << "Channel " << id_ << " done calling a send callback (#"
+               << sequenceNumber << ")";
+  };
+
+  if (error_ || buffer.length == 0) {
+    descriptorCallback(error_, std::string());
+    callback(error_);
+    return;
+  }
+
+  TP_VLOG(5) << "Channel " << id_
+             << " is copying buffer from CUDA device to CPU";
+  auto tmpBuffer = makeCudaPinnedBuffer(buffer.length);
+  TP_CUDA_CHECK(cudaMemcpyAsync(
+      tmpBuffer.get(),
+      buffer.ptr,
+      buffer.length,
+      cudaMemcpyDeviceToHost,
+      buffer.stream));
+
+  cudaLoop_.addCallback(
+      cudaDeviceForPointer(buffer.ptr),
+      buffer.stream,
+      eagerCallbackWrapper_([buffer,
+                             tmpBuffer{std::move(tmpBuffer)},
+                             descriptorCallback{std::move(descriptorCallback)}](
+                                Impl& impl) mutable {
+        impl.onTempBufferReadyForSend(
+            buffer, std::move(tmpBuffer), std::move(descriptorCallback));
+      }));
+
+  callback(Error::kSuccess);
+}
+
+void Channel::Impl::onTempBufferReadyForSend(
+    CudaBuffer buffer,
+    CudaPinnedBuffer tmpBuffer,
+    TDescriptorCallback descriptorCallback) {
+  if (error_) {
+    descriptorCallback(error_, std::string());
+    return;
+  }
+
+  TP_VLOG(5) << "Channel " << id_
+             << " is done copying buffer from CUDA device to CPU";
+
+  CpuBuffer cpuBuffer{tmpBuffer.get(), buffer.length};
+  // Keep tmpBuffer alive until cpuChannel_ is done sending it over.
+  // TODO: This could be a lazy callback wrapper.
+  auto callback =
+      eagerCallbackWrapper_([tmpBuffer{std::move(tmpBuffer)}](Impl& impl) {
+        TP_VLOG(5) << "Channel " << impl.id_
+                   << " is done sending buffer through CPU channel";
+      });
+  TP_VLOG(6) << "Channel " << id_ << " is sending buffer through CPU channel";
+  cpuChannel_->send(
+      cpuBuffer, std::move(descriptorCallback), std::move(callback));
+}
+
+// Receive memory region from peer.
+void Channel::recv(
+    TDescriptor descriptor,
+    CudaBuffer buffer,
+    TRecvCallback callback) {
+  impl_->recv(std::move(descriptor), buffer, std::move(callback));
+}
+
+void Channel::Impl::recv(
+    TDescriptor descriptor,
+    CudaBuffer buffer,
+    TRecvCallback callback) {
+  loop_.deferToLoop([this,
+                     descriptor{std::move(descriptor)},
+                     buffer,
+                     callback{std::move(callback)}]() mutable {
+    recvFromLoop(std::move(descriptor), buffer, std::move(callback));
+  });
+}
+
+void Channel::Impl::recvFromLoop(
+    TDescriptor descriptor,
+    CudaBuffer buffer,
+    TRecvCallback callback) {
+  TP_DCHECK(loop_.inLoop());
+
+  const uint64_t sequenceNumber = nextTensorBeingReceived_++;
+  TP_VLOG(4) << "Channel " << id_ << " received a recv request (#"
+             << sequenceNumber << ")";
+  callback = [this, sequenceNumber, callback{std::move(callback)}](
+                 const Error& error) {
+    TP_VLOG(4) << "Channel " << id_ << " is calling a recv callback (#"
+               << sequenceNumber << ")";
+    callback(error);
+    TP_VLOG(4) << "Channel " << id_ << " done calling a recv callback (#"
+               << sequenceNumber << ")";
+  };
+
+  if (error_ || buffer.length == 0) {
+    callback(error_);
+    return;
+  }
+
+  auto tmpBuffer = makeCudaPinnedBuffer(buffer.length);
+  CpuBuffer cpuBuffer{tmpBuffer.get(), buffer.length};
+
+  cpuChannel_->recv(
+      std::move(descriptor),
+      cpuBuffer,
+      eagerCallbackWrapper_(
+          [buffer,
+           tmpBuffer{std::move(tmpBuffer)},
+           callback{std::move(callback)}](Impl& impl) mutable {
+            impl.onCpuChannelRecv(
+                buffer, std::move(tmpBuffer), std::move(callback));
+          }));
+}
+
+void Channel::Impl::onCpuChannelRecv(
+    CudaBuffer buffer,
+    CudaPinnedBuffer tmpBuffer,
+    TRecvCallback callback) {
+  if (error_) {
+    callback(error_);
+    return;
+  }
+
+  TP_VLOG(5) << "Channel " << id_
+             << " is copying buffer from CPU to CUDA device";
+  TP_CUDA_CHECK(cudaMemcpyAsync(
+      buffer.ptr,
+      tmpBuffer.get(),
+      buffer.length,
+      cudaMemcpyHostToDevice,
+      buffer.stream));
+
+  // Keep tmpBuffer alive until cudaMemcpyAsync is done.
+  cudaLoop_.addCallback(
+      cudaDeviceForPointer(buffer.ptr),
+      buffer.stream,
+      eagerCallbackWrapper_(
+          [tmpBuffer{std::move(tmpBuffer)}](Impl& impl) mutable {
+            TP_VLOG(5) << "Channel " << impl.id_
+                       << " is done copying buffer from CPU to CUDA device";
+          }));
+
+  callback(Error::kSuccess);
+}
+
+void Channel::setId(std::string id) {
+  impl_->setId(std::move(id));
+}
+
+void Channel::Impl::setId(std::string id) {
+  loop_.deferToLoop(
+      [this, id{std::move(id)}]() mutable { setIdFromLoop(std::move(id)); });
+}
+
+void Channel::Impl::setIdFromLoop(std::string id) {
+  TP_DCHECK(loop_.inLoop());
+  TP_VLOG(4) << "Channel " << id_ << " was renamed to " << id;
+  id_ = std::move(id);
+  cpuChannel_->setId(id_ + ".cpu");
+}
+
+void Channel::close() {
+  impl_->close();
+}
+
+Channel::~Channel() {
+  close();
+}
+
+void Channel::Impl::close() {
+  loop_.deferToLoop([this]() { closeFromLoop(); });
+}
+
+void Channel::Impl::closeFromLoop() {
+  TP_DCHECK(loop_.inLoop());
+  setError(TP_CREATE_ERROR(ChannelClosedError));
+}
+
+void Channel::Impl::setError(Error error) {
+  // Don't overwrite an error that's already set.
+  if (error_ || !error) {
+    return;
+  }
+
+  error_ = std::move(error);
+
+  handleError();
+}
+
+void Channel::Impl::handleError() {
+  TP_DCHECK(loop_.inLoop());
+
+  cpuChannel_->close();
+}
+
+} // namespace cuda_basic
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_basic/channel.h
+++ b/tensorpipe/channel/cuda_basic/channel.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <tensorpipe/channel/channel.h>
+#include <tensorpipe/channel/cpu_context.h>
+#include <tensorpipe/channel/cuda_basic/context.h>
+#include <tensorpipe/channel/cuda_context.h>
+
+namespace tensorpipe {
+
+class CudaLoop;
+
+namespace channel {
+namespace cuda_basic {
+
+class Channel : public channel::CudaChannel {
+  // Use the passkey idiom to allow make_shared to call what should be a private
+  // constructor. See https://abseil.io/tips/134 for more information.
+  struct ConstructorToken {};
+
+ public:
+  Channel(
+      ConstructorToken token,
+      std::shared_ptr<Context::PrivateIface> context,
+      std::shared_ptr<CpuChannel> cpuChannel,
+      CudaLoop& cudaLoop,
+      std::string id);
+
+  // Send memory region to peer.
+  void send(
+      CudaBuffer buffer,
+      TDescriptorCallback descriptorCallback,
+      TSendCallback callback) override;
+
+  // Receive memory region from peer.
+  void recv(TDescriptor descriptor, CudaBuffer buffer, TRecvCallback callback)
+      override;
+
+  // Tell the channel what its identifier is.
+  void setId(std::string id) override;
+
+  void close() override;
+
+  ~Channel() override;
+
+ private:
+  class Impl;
+
+  // Using a shared_ptr allows us to detach the lifetime of the implementation
+  // from the public object's one and perform the destruction asynchronously.
+  std::shared_ptr<Impl> impl_;
+
+  // Allow context to access constructor token.
+  friend class Context;
+};
+
+} // namespace cuda_basic
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_basic/context.cc
+++ b/tensorpipe/channel/cuda_basic/context.cc
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/channel/cuda_basic/context.h>
+
+#include <algorithm>
+#include <list>
+
+#include <tensorpipe/channel/cuda_basic/channel.h>
+#include <tensorpipe/channel/cuda_basic/context_impl.h>
+#include <tensorpipe/channel/error.h>
+#include <tensorpipe/channel/helpers.h>
+#include <tensorpipe/common/callback.h>
+#include <tensorpipe/common/cuda_loop.h>
+#include <tensorpipe/common/defs.h>
+#include <tensorpipe/common/error.h>
+#include <tensorpipe/common/error_macros.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_basic {
+
+class Context::Impl : public Context::PrivateIface,
+                      public std::enable_shared_from_this<Context::Impl> {
+ public:
+  explicit Impl(std::shared_ptr<CpuContext> cpuContext);
+
+  const std::string& domainDescriptor() const;
+
+  std::shared_ptr<channel::CudaChannel> createChannel(
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint);
+
+  void setId(std::string id);
+
+  ClosingEmitter& getClosingEmitter() override;
+
+  void close();
+
+  void join();
+
+  ~Impl() override = default;
+
+ private:
+  std::atomic<bool> closed_{false};
+  std::atomic<bool> joined_{false};
+  ClosingEmitter closingEmitter_;
+
+  std::shared_ptr<CpuContext> cpuContext_;
+  // TODO: Lazy initialization of cuda loop.
+  CudaLoop cudaLoop_;
+  // An identifier for the context, composed of the identifier for the context,
+  // combined with the channel's name. It will only be used for logging and
+  // debugging purposes.
+  std::string id_{"N/A"};
+
+  // Sequence numbers for the channels created by this context, used to create
+  // their identifiers based off this context's identifier. They will only be
+  // used for logging and debugging.
+  std::atomic<uint64_t> channelCounter_{0};
+};
+
+Context::Context(std::shared_ptr<CpuContext> cpuContext)
+    : impl_(std::make_shared<Impl>(std::move(cpuContext))) {}
+
+Context::Impl::Impl(std::shared_ptr<CpuContext> cpuContext)
+    : cpuContext_(std::move(cpuContext)) {}
+
+void Context::close() {
+  impl_->close();
+}
+
+void Context::Impl::close() {
+  if (!closed_.exchange(true)) {
+    closingEmitter_.close();
+    cpuContext_->close();
+    cudaLoop_.close();
+  }
+}
+
+void Context::join() {
+  impl_->join();
+}
+
+void Context::Impl::join() {
+  close();
+
+  if (!joined_.exchange(true)) {
+    cpuContext_->join();
+    cudaLoop_.join();
+  }
+}
+
+Context::~Context() {
+  join();
+}
+
+void Context::setId(std::string id) {
+  impl_->setId(std::move(id));
+}
+
+void Context::Impl::setId(std::string id) {
+  id_ = std::move(id);
+  cpuContext_->setId(id_ + ".cpu");
+}
+
+ClosingEmitter& Context::Impl::getClosingEmitter() {
+  return closingEmitter_;
+}
+
+const std::string& Context::domainDescriptor() const {
+  return impl_->domainDescriptor();
+}
+
+const std::string& Context::Impl::domainDescriptor() const {
+  return cpuContext_->domainDescriptor();
+}
+
+std::shared_ptr<channel::CudaChannel> Context::createChannel(
+    std::shared_ptr<transport::Connection> connection,
+    Endpoint endpoint) {
+  return impl_->createChannel(std::move(connection), endpoint);
+}
+
+std::shared_ptr<channel::CudaChannel> Context::Impl::createChannel(
+    std::shared_ptr<transport::Connection> connection,
+    Endpoint endpoint) {
+  std::string channelId = id_ + ".c" + std::to_string(channelCounter_++);
+  TP_VLOG(4) << "Channel context " << id_ << " is opening channel "
+             << channelId;
+  auto cpuChannel = cpuContext_->createChannel(std::move(connection), endpoint);
+
+  return std::make_shared<Channel>(
+      Channel::ConstructorToken(),
+      std::static_pointer_cast<PrivateIface>(shared_from_this()),
+      std::move(cpuChannel),
+      cudaLoop_,
+      std::move(channelId));
+}
+
+} // namespace cuda_basic
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_basic/context.h
+++ b/tensorpipe/channel/cuda_basic/context.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <tensorpipe/channel/cpu_context.h>
+#include <tensorpipe/channel/cuda_context.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_basic {
+
+class Context : public channel::CudaContext {
+ public:
+  explicit Context(std::shared_ptr<CpuContext> cpuContext);
+
+  const std::string& domainDescriptor() const override;
+
+  std::shared_ptr<CudaChannel> createChannel(
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint) override;
+
+  void setId(std::string id) override;
+
+  void close() override;
+
+  void join() override;
+
+  ~Context() override;
+
+ private:
+  class PrivateIface;
+
+  class Impl;
+
+  // The implementation is managed by a shared_ptr because each child object
+  // will also hold a shared_ptr to it (downcast as a shared_ptr to the private
+  // interface). However, its lifetime is tied to the one of this public object,
+  // since when the latter is destroyed the implementation is closed and joined.
+  std::shared_ptr<Impl> impl_;
+
+  // Allow channel to see the private interface.
+  friend class Channel;
+};
+
+} // namespace cuda_basic
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_basic/context_impl.h
+++ b/tensorpipe/channel/cuda_basic/context_impl.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <tensorpipe/channel/cuda_basic/context.h>
+#include <tensorpipe/common/callback.h>
+
+namespace tensorpipe {
+namespace channel {
+namespace cuda_basic {
+
+class Context::PrivateIface {
+ public:
+  virtual ClosingEmitter& getClosingEmitter() = 0;
+
+  virtual ~PrivateIface() = default;
+};
+
+} // namespace cuda_basic
+} // namespace channel
+} // namespace tensorpipe

--- a/tensorpipe/channel/cuda_ipc/channel.cc
+++ b/tensorpipe/channel/cuda_ipc/channel.cc
@@ -141,9 +141,9 @@ struct RecvOperation {
 class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
  public:
   Impl(
-      std::shared_ptr<Context::PrivateIface>,
-      std::shared_ptr<transport::Connection>,
-      std::string);
+      std::shared_ptr<Context::PrivateIface> context,
+      std::shared_ptr<transport::Connection> connection,
+      std::string id);
 
   // Called by the channel's constructor.
   void init();

--- a/tensorpipe/channel/cuda_ipc/channel.h
+++ b/tensorpipe/channel/cuda_ipc/channel.h
@@ -28,8 +28,8 @@ class Channel : public channel::CudaChannel {
 
  public:
   Channel(
-      ConstructorToken,
-      std::shared_ptr<Context::PrivateIface>,
+      ConstructorToken token,
+      std::shared_ptr<Context::PrivateIface> context,
       std::shared_ptr<transport::Connection> connection,
       std::string id);
 

--- a/tensorpipe/channel/cuda_ipc/context.cc
+++ b/tensorpipe/channel/cuda_ipc/context.cc
@@ -51,8 +51,8 @@ class Context::Impl : public Context::PrivateIface,
   const std::string& domainDescriptor() const;
 
   std::shared_ptr<channel::CudaChannel> createChannel(
-      std::shared_ptr<transport::Connection>,
-      Endpoint);
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint);
 
   void setId(std::string id);
 

--- a/tensorpipe/channel/cuda_ipc/context.h
+++ b/tensorpipe/channel/cuda_ipc/context.h
@@ -24,8 +24,8 @@ class Context : public channel::CudaContext {
   const std::string& domainDescriptor() const override;
 
   std::shared_ptr<CudaChannel> createChannel(
-      std::shared_ptr<transport::Connection>,
-      Endpoint) override;
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint) override;
 
   void setId(std::string id) override;
 

--- a/tensorpipe/channel/cuda_xth/channel.cc
+++ b/tensorpipe/channel/cuda_xth/channel.cc
@@ -66,9 +66,9 @@ struct Descriptor {
 class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
  public:
   Impl(
-      std::shared_ptr<Context::PrivateIface>,
-      std::shared_ptr<transport::Connection>,
-      std::string);
+      std::shared_ptr<Context::PrivateIface> context,
+      std::shared_ptr<transport::Connection> connection,
+      std::string id);
 
   // Called by the channel's constructor.
   void init();

--- a/tensorpipe/channel/cuda_xth/channel.h
+++ b/tensorpipe/channel/cuda_xth/channel.h
@@ -25,8 +25,8 @@ class Channel : public channel::CudaChannel {
 
  public:
   Channel(
-      ConstructorToken,
-      std::shared_ptr<Context::PrivateIface>,
+      ConstructorToken token,
+      std::shared_ptr<Context::PrivateIface> context,
       std::shared_ptr<transport::Connection> connection,
       std::string id);
 

--- a/tensorpipe/channel/cuda_xth/context.cc
+++ b/tensorpipe/channel/cuda_xth/context.cc
@@ -52,8 +52,8 @@ class Context::Impl : public Context::PrivateIface,
   const std::string& domainDescriptor() const;
 
   std::shared_ptr<channel::CudaChannel> createChannel(
-      std::shared_ptr<transport::Connection>,
-      Endpoint);
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint);
 
   void setId(std::string id);
 

--- a/tensorpipe/channel/cuda_xth/context.h
+++ b/tensorpipe/channel/cuda_xth/context.h
@@ -27,8 +27,8 @@ class Context : public channel::CudaContext {
   const std::string& domainDescriptor() const override;
 
   std::shared_ptr<CudaChannel> createChannel(
-      std::shared_ptr<transport::Connection>,
-      Endpoint) override;
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint) override;
 
   void setId(std::string id) override;
 

--- a/tensorpipe/channel/mpt/channel.h
+++ b/tensorpipe/channel/mpt/channel.h
@@ -26,7 +26,7 @@ class Channel : public channel::CpuChannel {
 
  public:
   Channel(
-      ConstructorToken,
+      ConstructorToken token,
       std::shared_ptr<Context::PrivateIface> context,
       std::shared_ptr<transport::Connection> connection,
       Endpoint endpoint,

--- a/tensorpipe/channel/mpt/context.cc
+++ b/tensorpipe/channel/mpt/context.cc
@@ -34,8 +34,8 @@ class Context::Impl : public Context::PrivateIface,
                       public std::enable_shared_from_this<Context::Impl> {
  public:
   Impl(
-      std::vector<std::shared_ptr<transport::Context>>,
-      std::vector<std::shared_ptr<transport::Listener>>);
+      std::vector<std::shared_ptr<transport::Context>> contexts,
+      std::vector<std::shared_ptr<transport::Listener>> listeners);
 
   // Called by the context's constructor.
   void init();
@@ -43,8 +43,8 @@ class Context::Impl : public Context::PrivateIface,
   const std::string& domainDescriptor() const;
 
   std::shared_ptr<channel::CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection>,
-      Endpoint);
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint);
 
   ClosingEmitter& getClosingEmitter() override;
 
@@ -52,9 +52,9 @@ class Context::Impl : public Context::PrivateIface,
 
   uint64_t registerConnectionRequest(
       uint64_t laneIdx,
-      connection_request_callback_fn) override;
+      connection_request_callback_fn fn) override;
 
-  void unregisterConnectionRequest(uint64_t) override;
+  void unregisterConnectionRequest(uint64_t registrationId) override;
 
   std::shared_ptr<transport::Connection> connect(
       uint64_t laneIdx,
@@ -78,15 +78,15 @@ class Context::Impl : public Context::PrivateIface,
   void registerConnectionRequestFromLoop(
       uint64_t laneIdx,
       uint64_t registrationId,
-      connection_request_callback_fn);
+      connection_request_callback_fn fn);
 
-  void unregisterConnectionRequestFromLoop(uint64_t);
+  void unregisterConnectionRequestFromLoop(uint64_t registrationId);
 
-  void acceptLane(uint64_t);
-  void onAcceptOfLane(std::shared_ptr<transport::Connection>);
+  void acceptLane(uint64_t laneIdx);
+  void onAcceptOfLane(std::shared_ptr<transport::Connection> connection);
   void onReadClientHelloOnLane(
-      std::shared_ptr<transport::Connection>,
-      const Packet&);
+      std::shared_ptr<transport::Connection> connection,
+      const Packet& nopPacketIn);
 
   void setError(Error error);
 

--- a/tensorpipe/channel/mpt/context.h
+++ b/tensorpipe/channel/mpt/context.h
@@ -22,14 +22,14 @@ namespace mpt {
 class Context : public channel::CpuContext {
  public:
   Context(
-      std::vector<std::shared_ptr<transport::Context>>,
-      std::vector<std::shared_ptr<transport::Listener>>);
+      std::vector<std::shared_ptr<transport::Context>> contexts,
+      std::vector<std::shared_ptr<transport::Listener>> listeners);
 
   const std::string& domainDescriptor() const override;
 
   std::shared_ptr<CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection>,
-      Endpoint) override;
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint) override;
 
   void setId(std::string id) override;
 

--- a/tensorpipe/channel/mpt/nop_types.h
+++ b/tensorpipe/channel/mpt/nop_types.h
@@ -23,7 +23,7 @@ struct LaneAdvertisement {
   // This pointless constructor is needed to work around a bug in GCC 5.5 (and
   // possibly other versions). It appears to be needed in the nop types that are
   // used inside std::vectors.
-  LaneAdvertisement(){};
+  LaneAdvertisement() {}
 
   std::string address;
   uint64_t registrationId;

--- a/tensorpipe/channel/xth/channel.cc
+++ b/tensorpipe/channel/xth/channel.cc
@@ -36,9 +36,9 @@ struct Descriptor {
 class Channel::Impl : public std::enable_shared_from_this<Channel::Impl> {
  public:
   Impl(
-      std::shared_ptr<Context::PrivateIface>,
-      std::shared_ptr<transport::Connection>,
-      std::string);
+      std::shared_ptr<Context::PrivateIface> context,
+      std::shared_ptr<transport::Connection> connection,
+      std::string id);
 
   // Called by the channel's constructor.
   void init();

--- a/tensorpipe/channel/xth/channel.h
+++ b/tensorpipe/channel/xth/channel.h
@@ -26,8 +26,8 @@ class Channel : public channel::CpuChannel {
 
  public:
   Channel(
-      ConstructorToken,
-      std::shared_ptr<Context::PrivateIface>,
+      ConstructorToken token,
+      std::shared_ptr<Context::PrivateIface> context,
       std::shared_ptr<transport::Connection> connection,
       std::string id);
 

--- a/tensorpipe/channel/xth/context.cc
+++ b/tensorpipe/channel/xth/context.cc
@@ -53,8 +53,8 @@ class Context::Impl : public Context::PrivateIface,
   const std::string& domainDescriptor() const;
 
   std::shared_ptr<channel::CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection>,
-      Endpoint);
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint);
 
   void setId(std::string id);
 

--- a/tensorpipe/channel/xth/context.h
+++ b/tensorpipe/channel/xth/context.h
@@ -24,8 +24,8 @@ class Context : public channel::CpuContext {
   const std::string& domainDescriptor() const override;
 
   std::shared_ptr<CpuChannel> createChannel(
-      std::shared_ptr<transport::Connection>,
-      Endpoint) override;
+      std::shared_ptr<transport::Connection> connection,
+      Endpoint endpoint) override;
 
   void setId(std::string id) override;
 

--- a/tensorpipe/common/address.h
+++ b/tensorpipe/common/address.h
@@ -12,6 +12,6 @@
 
 namespace tensorpipe {
 
-std::tuple<std::string, std::string> splitSchemeOfURL(const std::string&);
+std::tuple<std::string, std::string> splitSchemeOfURL(const std::string& url);
 
 }

--- a/tensorpipe/common/busy_polling_loop.h
+++ b/tensorpipe/common/busy_polling_loop.h
@@ -39,12 +39,12 @@ class BusyPollingLoop : public EventLoopDeferredExecutor {
         std::this_thread::yield();
       }
     }
-  };
+  }
 
   void wakeupEventLoopToDeferFunction() override {
     ++deferredFunctionCount_;
     // No need to wake up the thread, since it is busy-waiting.
-  };
+  }
 
  private:
   std::atomic<bool> closed_{false};

--- a/tensorpipe/common/callback.h
+++ b/tensorpipe/common/callback.h
@@ -125,7 +125,7 @@ class LazyCallbackWrapper {
   LazyCallbackWrapper(
       std::enable_shared_from_this<TSubject>& subject,
       OnDemandDeferredExecutor& loop)
-      : subject_(subject), loop_(loop){};
+      : subject_(subject), loop_(loop) {}
 
   template <typename TBoundFn>
   auto operator()(TBoundFn&& fn) {
@@ -190,7 +190,7 @@ class EagerCallbackWrapper {
   EagerCallbackWrapper(
       std::enable_shared_from_this<TSubject>& subject,
       OnDemandDeferredExecutor& loop)
-      : subject_(subject), loop_(loop){};
+      : subject_(subject), loop_(loop) {}
 
   template <typename TBoundFn>
   auto operator()(TBoundFn&& fn) {

--- a/tensorpipe/common/callback.h
+++ b/tensorpipe/common/callback.h
@@ -54,7 +54,7 @@ namespace {
 
 // NOTE: This is an incomplete implementation of C++17's `std::apply`.
 template <typename F, typename T, size_t... I>
-auto cb_apply(F&& f, T&& t, std::index_sequence<I...>) {
+auto cb_apply(F&& f, T&& t, std::index_sequence<I...> /*unused*/) {
   return f(std::get<I>(std::forward<T>(t))...);
 }
 

--- a/tensorpipe/common/cuda_loop.cc
+++ b/tensorpipe/common/cuda_loop.cc
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <tensorpipe/common/cuda_loop.h>
+
+#include <tensorpipe/common/cuda.h>
+#include <tensorpipe/common/system.h>
+
+namespace tensorpipe {
+
+namespace {
+
+struct CudaCallback {
+  CudaLoop& loop;
+  std::function<void(const Error&)> callback;
+
+  CudaCallback(CudaLoop& loop, std::function<void(const Error&)> callback)
+      : loop(loop), callback(std::move(callback)) {}
+};
+
+class CudaLoopClosedError final : public BaseError {
+  std::string what() const override {
+    return "CUDA loop already closed";
+  }
+};
+
+} // namespace
+
+CudaLoop::CudaLoop() {
+  thread_ = std::thread([this]() {
+    setThreadName("TP_CUDA_callback_loop");
+    processCallbacks();
+  });
+}
+
+CudaLoop::~CudaLoop() {
+  join();
+}
+
+void CudaLoop::join() {
+  close();
+
+  if (!joined_.exchange(true)) {
+    thread_.join();
+  }
+}
+
+void CudaLoop::close() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (closed_) {
+    return;
+  }
+  closed_ = true;
+  cv_.notify_all();
+}
+
+void CudaLoop::processCallbacks() {
+  for (;;) {
+    std::deque<Operation> operations;
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+
+      if (operations_.empty()) {
+        if (closed_ && pendingOperations_ == 0) {
+          break;
+        } else {
+          cv_.wait(lock);
+        }
+      }
+
+      std::swap(operations, operations_);
+      pendingOperations_ -= operations.size();
+    }
+
+    for (auto& op : operations) {
+      op.callback(op.error);
+    }
+  }
+}
+
+void CudaLoop::addCallback(
+    int device,
+    cudaStream_t stream,
+    std::function<void(const Error&)> callback) {
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (closed_) {
+      callback(TP_CREATE_ERROR(CudaLoopClosedError));
+      return;
+    }
+    ++pendingOperations_;
+  }
+
+  auto cudaCallback =
+      std::make_unique<CudaCallback>(*this, std::move(callback));
+  TP_CUDA_CHECK(cudaSetDevice(device));
+  TP_CUDA_CHECK(cudaStreamAddCallback(
+      stream, runCudaCallback, cudaCallback.release(), 0));
+}
+
+void CUDART_CB CudaLoop::runCudaCallback(
+    cudaStream_t /* unused */,
+    cudaError_t cudaError,
+    void* callbackPtr) {
+  std::unique_ptr<CudaCallback> cudaCallback(
+      reinterpret_cast<CudaCallback*>(callbackPtr));
+  CudaLoop& loop = cudaCallback->loop;
+  {
+    std::unique_lock<std::mutex> lock(loop.mutex_);
+    auto error = Error::kSuccess;
+    if (cudaError != cudaSuccess) {
+      error = TP_CREATE_ERROR(CudaError, cudaError);
+    }
+    loop.operations_.push_back(
+        {std::move(cudaCallback->callback), std::move(error)});
+    loop.cv_.notify_all();
+  }
+  cudaCallback.reset();
+}
+
+} // namespace tensorpipe

--- a/tensorpipe/common/cuda_loop.h
+++ b/tensorpipe/common/cuda_loop.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <list>
+#include <mutex>
+#include <thread>
+
+#include <cuda_runtime.h>
+
+#include <tensorpipe/common/error_macros.h>
+
+namespace tensorpipe {
+
+class CudaLoop {
+  struct Operation {
+    std::function<void(const Error&)> callback;
+    Error error;
+  };
+
+ public:
+  CudaLoop();
+
+  ~CudaLoop();
+
+  void join();
+  void close();
+
+  void addCallback(
+      int device,
+      cudaStream_t stream,
+      std::function<void(const Error&)> callback);
+
+ private:
+  std::thread thread_;
+  std::deque<Operation> operations_;
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  uint64_t pendingOperations_{0};
+
+  bool closed_{false};
+  std::atomic<bool> joined_{false};
+
+  void processCallbacks();
+
+  // Proxy static method for cudaStreamAddCallback(), which does not accept
+  // lambdas.
+  static void CUDART_CB runCudaCallback(
+      cudaStream_t stream,
+      cudaError_t cudaError,
+      void* callbackPtr);
+};
+
+} // namespace tensorpipe

--- a/tensorpipe/common/deferred_executor.h
+++ b/tensorpipe/common/deferred_executor.h
@@ -143,7 +143,7 @@ class EventLoopDeferredExecutor : public virtual DeferredExecutor {
     // Must call it without holding the lock, as it could cause a reentrant
     // call.
     onDemandLoop_.deferToLoop(std::move(fn));
-  };
+  }
 
   inline bool inLoop() override {
     {

--- a/tensorpipe/common/defs.h
+++ b/tensorpipe/common/defs.h
@@ -110,7 +110,7 @@ inline std::error_code toErrorCode(ssize_t e) {
 //
 class LogEntry final {
  public:
-  LogEntry(char type) {
+  explicit LogEntry(char type) {
     oss_ << type;
 
     // In C++17 use std::timespec.

--- a/tensorpipe/common/dl.h
+++ b/tensorpipe/common/dl.h
@@ -21,7 +21,7 @@ namespace tensorpipe {
 
 class DlError final : public BaseError {
  public:
-  DlError(char* error) : error_(error) {}
+  explicit DlError(char* error) : error_(error) {}
 
   std::string what() const override {
     return error_;

--- a/tensorpipe/common/ibv_lib.h
+++ b/tensorpipe/common/ibv_lib.h
@@ -611,7 +611,8 @@ class IbvLib {
   };
 
  private:
-  IbvLib(DynamicLibraryHandle dlhandle) : dlhandle_(std::move(dlhandle)) {}
+  explicit IbvLib(DynamicLibraryHandle dlhandle)
+      : dlhandle_(std::move(dlhandle)) {}
 
   DynamicLibraryHandle dlhandle_;
 

--- a/tensorpipe/common/ringbuffer_read_write_ops.h
+++ b/tensorpipe/common/ringbuffer_read_write_ops.h
@@ -49,7 +49,7 @@ class RingbufferReadOperation {
       read_callback_fn fn);
 
   // Processes a pending read.
-  inline size_t handleRead(util::ringbuffer::Consumer& consumer);
+  inline size_t handleRead(util::ringbuffer::Consumer& inbox);
 
   bool completed() const {
     return (mode_ == READ_PAYLOAD && bytesRead_ == len_);
@@ -70,7 +70,7 @@ class RingbufferReadOperation {
   // case we must check that the length matches the header we see on the wire.
   const bool ptrProvided_;
 
-  inline ssize_t readNopObject(util::ringbuffer::Consumer& consumer);
+  inline ssize_t readNopObject(util::ringbuffer::Consumer& inbox);
 };
 
 // Writes happen only if the user supplied a memory pointer, the
@@ -98,7 +98,7 @@ class RingbufferWriteOperation {
       const AbstractNopHolder* nopObject,
       write_callback_fn fn);
 
-  inline size_t handleWrite(util::ringbuffer::Producer& producer);
+  inline size_t handleWrite(util::ringbuffer::Producer& outbox);
 
   bool completed() const {
     return (mode_ == WRITE_PAYLOAD && bytesWritten_ == len_);
@@ -114,7 +114,7 @@ class RingbufferWriteOperation {
   size_t bytesWritten_{0};
   write_callback_fn fn_;
 
-  inline ssize_t writeNopObject(util::ringbuffer::Producer& producer);
+  inline ssize_t writeNopObject(util::ringbuffer::Producer& outbox);
 };
 
 RingbufferReadOperation::RingbufferReadOperation(

--- a/tensorpipe/common/socket.h
+++ b/tensorpipe/common/socket.h
@@ -35,7 +35,7 @@ void saveOneFdToArray(int& dst, const Fd& src) {
 template <size_t... Idxs, typename... Fds>
 void saveFdsToArray(
     int* array,
-    std::index_sequence<Idxs...>,
+    std::index_sequence<Idxs...> /*unused*/,
     const Fds&... fds) {
   // This is a trick to do pack expansion of the function call.
   auto dummy = {(saveOneFdToArray(array[Idxs], fds), 0)...};
@@ -50,7 +50,10 @@ void loadOneFdFromArray(int& src, Fd& dst) {
 }
 
 template <size_t... Idxs, typename... Fds>
-void loadFdsFromArray(int* array, std::index_sequence<Idxs...>, Fds&... fds) {
+void loadFdsFromArray(
+    int* array,
+    std::index_sequence<Idxs...> /*unused*/,
+    Fds&... fds) {
   // This is a trick to do pack expansion of the function call.
   auto dummy = {(loadOneFdFromArray(array[Idxs], fds), 0)...};
 }

--- a/tensorpipe/common/stream_read_write_ops.h
+++ b/tensorpipe/common/stream_read_write_ops.h
@@ -43,7 +43,7 @@ class StreamReadOperation {
   inline StreamReadOperation(void* ptr, size_t length, read_callback_fn fn);
 
   // Called when a buffer is needed to read data from stream.
-  inline void allocFromLoop(char** buf, size_t* len);
+  inline void allocFromLoop(char** base, size_t* len);
 
   // Called when data has been read from stream.
   inline void readFromLoop(size_t nread);

--- a/tensorpipe/core/context.cc
+++ b/tensorpipe/core/context.cc
@@ -49,28 +49,29 @@ class Context::Impl : public Context::PrivateIface,
   explicit Impl(ContextOptions opts);
 
   void registerTransport(
-      int64_t,
-      std::string,
-      std::shared_ptr<transport::Context>);
+      int64_t priority,
+      std::string transport,
+      std::shared_ptr<transport::Context> context);
 
   template <typename TBuffer>
   void registerChannel(
-      int64_t,
-      std::string,
-      std::shared_ptr<channel::Context<TBuffer>>);
+      int64_t priority,
+      std::string channel,
+      std::shared_ptr<channel::Context<TBuffer>> context);
 
-  std::shared_ptr<Listener> listen(const std::vector<std::string>&);
+  std::shared_ptr<Listener> listen(const std::vector<std::string>& urls);
 
-  std::shared_ptr<Pipe> connect(const std::string&, PipeOptions opts);
+  std::shared_ptr<Pipe> connect(const std::string& url, PipeOptions opts);
 
   ClosingEmitter& getClosingEmitter() override;
 
-  std::shared_ptr<transport::Context> getTransport(const std::string&) override;
+  std::shared_ptr<transport::Context> getTransport(
+      const std::string& transport) override;
   std::shared_ptr<channel::CpuContext> getCpuChannel(
-      const std::string&) override;
+      const std::string& channel) override;
 #if TENSORPIPE_SUPPORTS_CUDA
   std::shared_ptr<channel::CudaContext> getCudaChannel(
-      const std::string&) override;
+      const std::string& channel) override;
 #endif // TENSORPIPE_SUPPORTS_CUDA
 
   using PrivateIface::TOrderedTransports;
@@ -130,7 +131,8 @@ class Context::Impl : public Context::PrivateIface,
   ClosingEmitter closingEmitter_;
 
   template <typename TBuffer>
-  std::shared_ptr<channel::Context<TBuffer>> getChannel(const std::string&);
+  std::shared_ptr<channel::Context<TBuffer>> getChannel(
+      const std::string& channel);
 };
 
 Context::Context(ContextOptions opts)

--- a/tensorpipe/core/context.h
+++ b/tensorpipe/core/context.h
@@ -56,14 +56,14 @@ class Context final {
   explicit Context(ContextOptions opts = ContextOptions());
 
   void registerTransport(
-      int64_t,
-      std::string,
-      std::shared_ptr<transport::Context>);
+      int64_t priority,
+      std::string transport,
+      std::shared_ptr<transport::Context> context);
 
   void registerChannel(
-      int64_t,
-      std::string,
-      std::shared_ptr<channel::CpuContext>);
+      int64_t priority,
+      std::string channel,
+      std::shared_ptr<channel::CpuContext> context);
 
 #if TENSORPIPE_SUPPORTS_CUDA
   void registerChannel(
@@ -72,10 +72,10 @@ class Context final {
       std::shared_ptr<channel::CudaContext>);
 #endif // TENSORPIPE_SUPPORTS_CUDA
 
-  std::shared_ptr<Listener> listen(const std::vector<std::string>&);
+  std::shared_ptr<Listener> listen(const std::vector<std::string>& urls);
 
   std::shared_ptr<Pipe> connect(
-      const std::string&,
+      const std::string& url,
       PipeOptions opts = PipeOptions());
 
   // Put the context in a terminal state, in turn closing all of its pipes and

--- a/tensorpipe/core/listener.cc
+++ b/tensorpipe/core/listener.cc
@@ -30,14 +30,14 @@ class Listener::Impl : public Listener::PrivateIface,
                        public std::enable_shared_from_this<Listener::Impl> {
  public:
   Impl(
-      std::shared_ptr<Context::PrivateIface>,
+      std::shared_ptr<Context::PrivateIface> context,
       std::string id,
       const std::vector<std::string>& urls);
 
   // Called by the listener's constructor.
   void init();
 
-  void accept(accept_callback_fn);
+  void accept(accept_callback_fn fn);
 
   const std::map<std::string, std::string>& addresses() const override;
 
@@ -47,8 +47,9 @@ class Listener::Impl : public Listener::PrivateIface,
 
   using PrivateIface::connection_request_callback_fn;
 
-  uint64_t registerConnectionRequest(connection_request_callback_fn) override;
-  void unregisterConnectionRequest(uint64_t) override;
+  uint64_t registerConnectionRequest(
+      connection_request_callback_fn fn) override;
+  void unregisterConnectionRequest(uint64_t registrationId) override;
 
   void close();
 
@@ -57,7 +58,7 @@ class Listener::Impl : public Listener::PrivateIface,
  private:
   OnDemandDeferredExecutor loop_;
 
-  void acceptFromLoop(accept_callback_fn);
+  void acceptFromLoop(accept_callback_fn fn);
 
   void closeFromLoop();
 
@@ -115,10 +116,10 @@ class Listener::Impl : public Listener::PrivateIface,
   //
 
   void registerConnectionRequestFromLoop(
-      uint64_t,
-      connection_request_callback_fn);
+      uint64_t registrationId,
+      connection_request_callback_fn fn);
 
-  void unregisterConnectionRequestFromLoop(uint64_t);
+  void unregisterConnectionRequestFromLoop(uint64_t registrationId);
 
   //
   // Helpers to prepare callbacks from transports
@@ -138,12 +139,14 @@ class Listener::Impl : public Listener::PrivateIface,
   // Everything else
   //
 
-  void armListener(std::string);
-  void onAccept(std::string, std::shared_ptr<transport::Connection>);
+  void armListener(std::string transport);
+  void onAccept(
+      std::string transport,
+      std::shared_ptr<transport::Connection> connection);
   void onConnectionHelloRead(
-      std::string,
-      std::shared_ptr<transport::Connection>,
-      const Packet&);
+      std::string transport,
+      std::shared_ptr<transport::Connection> connection,
+      const Packet& nopPacketIn);
 
   template <typename T>
   friend class LazyCallbackWrapper;

--- a/tensorpipe/core/listener.h
+++ b/tensorpipe/core/listener.h
@@ -39,7 +39,7 @@ class Listener final {
 
  public:
   Listener(
-      ConstructorToken,
+      ConstructorToken token,
       std::shared_ptr<Context::PrivateIface> context,
       std::string id,
       const std::vector<std::string>& urls);
@@ -51,7 +51,7 @@ class Listener final {
   using accept_callback_fn =
       std::function<void(const Error&, std::shared_ptr<Pipe>)>;
 
-  void accept(accept_callback_fn);
+  void accept(accept_callback_fn fn);
 
   // Returns map with the materialized address of listeners by transport.
   //

--- a/tensorpipe/core/nop_types.h
+++ b/tensorpipe/core/nop_types.h
@@ -78,7 +78,7 @@ struct MessageDescriptor {
     // This pointless constructor is needed to work around a bug in GCC 5.5 (and
     // possibly other versions). It appears to be needed in the nop types that
     // are used inside std::vectors.
-    PayloadDescriptor(){};
+    PayloadDescriptor() {}
 
     int64_t sizeInBytes;
     std::string metadata;
@@ -89,7 +89,7 @@ struct MessageDescriptor {
     // This pointless constructor is needed to work around a bug in GCC 5.5 (and
     // possibly other versions). It appears to be needed in the nop types that
     // are used inside std::vectors.
-    TensorDescriptor(){};
+    TensorDescriptor() {}
 
     int64_t sizeInBytes;
     std::string metadata;

--- a/tensorpipe/core/pipe.cc
+++ b/tensorpipe/core/pipe.cc
@@ -353,9 +353,9 @@ class Pipe::Impl : public std::enable_shared_from_this<Pipe::Impl> {
   // Called by the pipe's constructor.
   void init();
 
-  void readDescriptor(read_descriptor_callback_fn);
-  void read(Message, read_callback_fn);
-  void write(Message, write_callback_fn);
+  void readDescriptor(read_descriptor_callback_fn fn);
+  void read(Message message, read_callback_fn fn);
+  void write(Message message, write_callback_fn fn);
 
   const std::string& getRemoteName();
 
@@ -366,11 +366,11 @@ class Pipe::Impl : public std::enable_shared_from_this<Pipe::Impl> {
 
   void initFromLoop();
 
-  void readDescriptorFromLoop(read_descriptor_callback_fn);
+  void readDescriptorFromLoop(read_descriptor_callback_fn fn);
 
-  void readFromLoop(Message, read_callback_fn);
+  void readFromLoop(Message message, read_callback_fn fn);
 
-  void writeFromLoop(Message, write_callback_fn);
+  void writeFromLoop(Message message, write_callback_fn fn);
 
   void closeFromLoop();
 
@@ -486,26 +486,29 @@ class Pipe::Impl : public std::enable_shared_from_this<Pipe::Impl> {
   bool advanceOneReadOperation(ReadOperation& op);
   bool advanceOneWriteOperation(WriteOperation& op);
 
-  void readDescriptorOfMessage(ReadOperation&);
-  void readPayloadsAndReceiveTensorsOfMessage(ReadOperation&);
-  void sendTensorsOfMessage(WriteOperation&);
-  void writeDescriptorAndPayloadsOfMessage(WriteOperation&);
-  void onReadWhileServerWaitingForBrochure(const Packet&);
-  void onReadWhileClientWaitingForBrochureAnswer(const Packet&);
+  void readDescriptorOfMessage(ReadOperation& op);
+  void readPayloadsAndReceiveTensorsOfMessage(ReadOperation& op);
+  void sendTensorsOfMessage(WriteOperation& op);
+  void writeDescriptorAndPayloadsOfMessage(WriteOperation& op);
+  void onReadWhileServerWaitingForBrochure(const Packet& nopPacketIn);
+  void onReadWhileClientWaitingForBrochureAnswer(const Packet& nopPacketIn);
   void onAcceptWhileServerWaitingForConnection(
-      std::string,
-      std::shared_ptr<transport::Connection>);
+      std::string receivedTransport,
+      std::shared_ptr<transport::Connection> receivedConnection);
   template <typename TBuffer>
   void onAcceptWhileServerWaitingForChannel(
-      std::string,
-      std::string,
-      std::shared_ptr<transport::Connection>);
-  void onReadOfMessageDescriptor(ReadOperation&, const Packet&);
-  void onDescriptorOfTensor(WriteOperation&, int64_t, channel::TDescriptor);
-  void onReadOfPayload(ReadOperation&);
-  void onRecvOfTensor(ReadOperation&);
-  void onWriteOfPayload(WriteOperation&);
-  void onSendOfTensor(WriteOperation&);
+      std::string channelName,
+      std::string receivedTransport,
+      std::shared_ptr<transport::Connection> receivedConnection);
+  void onReadOfMessageDescriptor(ReadOperation& op, const Packet& nopPacketIn);
+  void onDescriptorOfTensor(
+      WriteOperation& op,
+      int64_t tensorIdx,
+      channel::TDescriptor descriptor);
+  void onReadOfPayload(ReadOperation& op);
+  void onRecvOfTensor(ReadOperation& op);
+  void onWriteOfPayload(WriteOperation& op);
+  void onSendOfTensor(WriteOperation& op);
 
   ReadOperation* findReadOperation(int64_t sequenceNumber);
   WriteOperation* findWriteOperation(int64_t sequenceNumber);

--- a/tensorpipe/core/pipe.h
+++ b/tensorpipe/core/pipe.h
@@ -45,14 +45,14 @@ class Pipe final {
   //
 
   Pipe(
-      ConstructorToken,
+      ConstructorToken token,
       std::shared_ptr<Context::PrivateIface> context,
       std::string id,
       std::string remoteName,
       const std::string& url);
 
   Pipe(
-      ConstructorToken,
+      ConstructorToken token,
       std::shared_ptr<Context::PrivateIface> context,
       std::shared_ptr<Listener::PrivateIface> listener,
       std::string id,
@@ -67,15 +67,15 @@ class Pipe final {
   using read_descriptor_callback_fn =
       std::function<void(const Error&, Message)>;
 
-  void readDescriptor(read_descriptor_callback_fn);
+  void readDescriptor(read_descriptor_callback_fn fn);
 
   using read_callback_fn = std::function<void(const Error&, Message)>;
 
-  void read(Message, read_callback_fn);
+  void read(Message message, read_callback_fn fn);
 
   using write_callback_fn = std::function<void(const Error&, Message)>;
 
-  void write(Message, write_callback_fn);
+  void write(Message message, write_callback_fn fn);
 
   // Retrieve the user-defined name that was given to the constructor of the
   // context on the remote side, if any (if not, this will be the empty string).

--- a/tensorpipe/test/CMakeLists.txt
+++ b/tensorpipe/test/CMakeLists.txt
@@ -68,6 +68,7 @@ if(TP_USE_CUDA)
 
   target_sources(tensorpipe_test PRIVATE
     channel/cuda_xth/cuda_xth_test.cc
+    channel/cuda_basic/cuda_basic_test.cc
     )
 
   if(TP_ENABLE_CUDA_IPC)

--- a/tensorpipe/test/channel/channel_test.h
+++ b/tensorpipe/test/channel/channel_test.h
@@ -231,8 +231,10 @@ class ClientServerChannelTestCase : public ChannelTestCase<TBuffer> {
         });
   }
 
-  virtual void server(std::shared_ptr<tensorpipe::transport::Connection>) {}
-  virtual void client(std::shared_ptr<tensorpipe::transport::Connection>) {}
+  virtual void server(
+      std::shared_ptr<tensorpipe::transport::Connection> connection) {}
+  virtual void client(
+      std::shared_ptr<tensorpipe::transport::Connection> connection) {}
 
  protected:
   ChannelTestHelper<TBuffer>* helper_;

--- a/tensorpipe/test/channel/cuda_basic/cuda_basic_test.cc
+++ b/tensorpipe/test/channel/cuda_basic/cuda_basic_test.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <numeric>
+
+#include <tensorpipe/channel/basic/context.h>
+#include <tensorpipe/channel/cuda_basic/context.h>
+#include <tensorpipe/test/channel/channel_test.h>
+
+namespace {
+
+class CudaBasicChannelTestHelper
+    : public ChannelTestHelper<tensorpipe::CudaBuffer> {
+ public:
+  std::shared_ptr<tensorpipe::channel::CudaContext> makeContext(
+      std::string id) override {
+    auto cpuContext = std::make_shared<tensorpipe::channel::basic::Context>();
+    auto context = std::make_shared<tensorpipe::channel::cuda_basic::Context>(
+        std::move(cpuContext));
+    context->setId(std::move(id));
+    return context;
+  }
+
+  std::shared_ptr<PeerGroup> makePeerGroup() override {
+    return std::make_shared<ProcessPeerGroup>();
+  }
+};
+
+CudaBasicChannelTestHelper helper;
+
+} // namespace
+
+INSTANTIATE_TEST_CASE_P(
+    CudaBasic,
+    CudaChannelTestSuite,
+    ::testing::Values(&helper));

--- a/tensorpipe/test/peer_group.h
+++ b/tensorpipe/test/peer_group.h
@@ -97,7 +97,7 @@ class ForkedThreadPeerGroup : public ThreadPeerGroup {
     TP_THROW_SYSTEM_IF(pid < 0, errno) << "Failed to fork";
     if (pid == 0) {
       ThreadPeerGroup::spawn(f1, f2);
-      std::exit(testing::Test::HasFailure());
+      std::exit(((testing::Test::HasFailure()) ? 1 : 0));
     }
 
     int status;
@@ -168,7 +168,7 @@ class ProcessPeerGroup : public PeerGroup {
 
         fns[peerId]();
 
-        std::exit(testing::Test::HasFailure());
+        std::exit(((testing::Test::HasFailure()) ? 1 : 0));
       }
     }
 

--- a/tensorpipe/test/transport/listener_test.cc
+++ b/tensorpipe/test/transport/listener_test.cc
@@ -56,18 +56,19 @@ TEST_P(TransportTest, Listener_AcceptCallbacksAreQueued) {
     int numAccepts = 0;
     std::promise<void> donePromise;
     for (int i = 0; i < 10; ++i) {
-      listener->accept([&, i](const Error& error, std::shared_ptr<Connection>) {
-        if (error) {
-          donePromise.set_exception(
-              std::make_exception_ptr(std::runtime_error(error.what())));
-        } else {
-          EXPECT_EQ(i, numAccepts);
-          numAccepts++;
-          if (numAccepts == 10) {
-            donePromise.set_value();
-          }
-        }
-      });
+      listener->accept(
+          [&, i](const Error& error, std::shared_ptr<Connection> /*unused*/) {
+            if (error) {
+              donePromise.set_exception(
+                  std::make_exception_ptr(std::runtime_error(error.what())));
+            } else {
+              EXPECT_EQ(i, numAccepts);
+              numAccepts++;
+              if (numAccepts == 10) {
+                donePromise.set_value();
+              }
+            }
+          });
     }
 
     // Avoid connections to be destroyed before being established.
@@ -97,18 +98,19 @@ TEST_P(TransportTest, Listener_IncomingConnectionsAreQueued) {
       conns.push_back(std::move(c));
     }
     for (int i = 0; i < 10; ++i) {
-      listener->accept([&, i](const Error& error, std::shared_ptr<Connection>) {
-        if (error) {
-          donePromise.set_exception(
-              std::make_exception_ptr(std::runtime_error(error.what())));
-        } else {
-          EXPECT_EQ(i, numAccepts);
-          numAccepts++;
-          if (numAccepts == 10) {
-            donePromise.set_value();
-          }
-        }
-      });
+      listener->accept(
+          [&, i](const Error& error, std::shared_ptr<Connection> /*unused*/) {
+            if (error) {
+              donePromise.set_exception(
+                  std::make_exception_ptr(std::runtime_error(error.what())));
+            } else {
+              EXPECT_EQ(i, numAccepts);
+              numAccepts++;
+              if (numAccepts == 10) {
+                donePromise.set_value();
+              }
+            }
+          });
     }
 
     donePromise.get_future().get();

--- a/tensorpipe/transport/context_impl_boilerplate.h
+++ b/tensorpipe/transport/context_impl_boilerplate.h
@@ -26,7 +26,7 @@ template <typename TCtx, typename TList, typename TConn>
 class ContextImplBoilerplate : public virtual DeferredExecutor,
                                public std::enable_shared_from_this<TCtx> {
  public:
-  ContextImplBoilerplate(std::string domainDescriptor);
+  explicit ContextImplBoilerplate(std::string domainDescriptor);
 
   ContextImplBoilerplate(const ContextImplBoilerplate&) = delete;
   ContextImplBoilerplate(ContextImplBoilerplate&&) = delete;

--- a/tensorpipe/transport/ibv/error.h
+++ b/tensorpipe/transport/ibv/error.h
@@ -28,7 +28,7 @@ class IbvError final : public BaseError {
 
 class GetaddrinfoError final : public BaseError {
  public:
-  GetaddrinfoError(int error) : error_(error) {}
+  explicit GetaddrinfoError(int error) : error_(error) {}
 
   std::string what() const override;
 

--- a/tensorpipe/transport/ibv/sockaddr.h
+++ b/tensorpipe/transport/ibv/sockaddr.h
@@ -21,7 +21,7 @@ namespace ibv {
 
 class Sockaddr final : public tensorpipe::Sockaddr {
  public:
-  static Sockaddr createInetSockAddr(const std::string& name);
+  static Sockaddr createInetSockAddr(const std::string& str);
 
   Sockaddr(const struct sockaddr* addr, socklen_t addrlen) {
     TP_ARG_CHECK(addr != nullptr);

--- a/tensorpipe/transport/uv/error.h
+++ b/tensorpipe/transport/uv/error.h
@@ -18,7 +18,7 @@ namespace uv {
 
 class UVError final : public BaseError {
  public:
-  UVError(int error) : error_(error) {}
+  explicit UVError(int error) : error_(error) {}
 
   std::string what() const override;
 

--- a/tensorpipe/transport/uv/sockaddr.h
+++ b/tensorpipe/transport/uv/sockaddr.h
@@ -21,7 +21,7 @@ namespace uv {
 
 class Sockaddr final : public tensorpipe::Sockaddr {
  public:
-  static Sockaddr createInetSockAddr(const std::string& name);
+  static Sockaddr createInetSockAddr(const std::string& str);
 
   Sockaddr(const struct sockaddr* addr, socklen_t addrlen) {
     TP_ARG_CHECK(addr != nullptr);

--- a/tensorpipe/transport/uv/uv.h
+++ b/tensorpipe/transport/uv/uv.h
@@ -109,7 +109,7 @@ class WriteRequest final : public BaseRequest<WriteRequest, uv_write_t> {
  public:
   using TWriteCallback = std::function<void(int status)>;
 
-  WriteRequest(TWriteCallback fn) : writeCallback_(std::move(fn)) {}
+  explicit WriteRequest(TWriteCallback fn) : writeCallback_(std::move(fn)) {}
 
   static int perform(
       uv_stream_t* handle,
@@ -240,7 +240,8 @@ class ConnectRequest final : public BaseRequest<ConnectRequest, uv_connect_t> {
  public:
   using TConnectCallback = std::function<void(int status)>;
 
-  ConnectRequest(TConnectCallback fn) : connectCallback_(std::move(fn)) {}
+  explicit ConnectRequest(TConnectCallback fn)
+      : connectCallback_(std::move(fn)) {}
 
   static int perform(
       uv_tcp_t* handle,

--- a/tensorpipe/util/ringbuffer/consumer.h
+++ b/tensorpipe/util/ringbuffer/consumer.h
@@ -23,7 +23,8 @@ class Consumer {
  public:
   Consumer() = delete;
 
-  Consumer(RingBuffer& rb) : header_{rb.getHeader()}, data_{rb.getData()} {
+  explicit Consumer(RingBuffer& rb)
+      : header_{rb.getHeader()}, data_{rb.getData()} {
     TP_THROW_IF_NULLPTR(data_);
   }
 

--- a/tensorpipe/util/ringbuffer/producer.h
+++ b/tensorpipe/util/ringbuffer/producer.h
@@ -23,7 +23,8 @@ class Producer {
  public:
   Producer() = delete;
 
-  Producer(RingBuffer& rb) : header_{rb.getHeader()}, data_{rb.getData()} {
+  explicit Producer(RingBuffer& rb)
+      : header_{rb.getHeader()}, data_{rb.getData()} {
     TP_THROW_IF_NULLPTR(data_);
   }
 

--- a/tensorpipe/util/ringbuffer/ringbuffer.h
+++ b/tensorpipe/util/ringbuffer/ringbuffer.h
@@ -63,7 +63,7 @@ class RingBufferHeader {
   // Implementation uses power of 2 arithmetic to avoid costly modulo.
   // So build the largest RingBuffer with size of the smallest power of 2 >=
   // <byte_size>.
-  RingBufferHeader(uint64_t min_data_byte_size)
+  explicit RingBufferHeader(uint64_t min_data_byte_size)
       : kDataPoolByteSize{nextPow2(min_data_byte_size)},
         kDataModMask{kDataPoolByteSize - 1} {
     // Minimum size where implementation of bit shift arithmetic works.


### PR DESCRIPTION
Summary:
I ran all the default internal linters on all our files, and accepted all the provided suggestions. They're all harmless: removing extra semicolons, adding explicit to constructors, ...

I did it so that when I enable new linters later on I can run them and see their effects without the "pollution" from these older issues.

Reviewed By: patricklabatut

Differential Revision: D25196334

fbshipit-source-id: f4ed557671c40ddbc2c8baa2b5cd0fa5dc70ec56